### PR TITLE
Implement server-side word gift claiming

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,12 @@
 This is a NextJS starter in Firebase Studio.
 
 To get started, take a look at src/app/page.tsx.
+
+## Word Gift Claiming Flow
+
+Administrators can gift unclaimed words to players. Gifts are stored in the
+`WordGifts` collection and include the recipient's user ID. When a player visits
+`/claim-word/[giftId]` the app calls a server action that performs a Firestore
+transaction to assign the word and mark the gift as claimed. Firestore security
+rules allow only the recipient to read the gift and update its `status` and
+`claimedAt` fields during this process.

--- a/firestore.rules
+++ b/firestore.rules
@@ -130,6 +130,14 @@ service cloud.firestore {
       allow create, update: if isSignedIn(); // Handled by server functions
       allow delete: if false; // Transfers should expire or be resolved, not deleted by users
     }
+
+    match /WordGifts/{giftId} {
+      allow read: if isSignedIn() && request.auth.uid == resource.data.recipientUserId;
+      allow update: if isSignedIn() &&
+                       request.auth.uid == resource.data.recipientUserId &&
+                       request.resource.data.keys().hasOnly(['status', 'claimedAt']);
+      allow create, delete: if false; // Only admins via server actions
+    }
     
     match /Notifications/{notificationId} {
       allow read, update: if isUser(resource.data.userId);

--- a/src/app/claim-word/[claimId]/actions.ts
+++ b/src/app/claim-word/[claimId]/actions.ts
@@ -1,0 +1,46 @@
+'use server';
+
+import { firestore } from '@/lib/firebase';
+import { doc, runTransaction, serverTimestamp, Timestamp } from 'firebase/firestore';
+import type { WordGift, MasterWordType } from '@/types';
+
+export async function claimGiftedWordServerAction(claimId: string, userId: string): Promise<{ success: boolean; error?: string; wordText?: string }> {
+  const giftRef = doc(firestore, 'WordGifts', claimId);
+  try {
+    return await runTransaction(firestore, async (transaction) => {
+      const giftSnap = await transaction.get(giftRef);
+      if (!giftSnap.exists()) {
+        throw new Error('This gift link is invalid or has expired.');
+      }
+
+      const giftData = giftSnap.data() as WordGift;
+
+      if (giftData.recipientUserId !== userId) {
+        throw new Error('This gift is not intended for you. Please log in with the correct account.');
+      }
+      if (giftData.status !== 'PendingClaim') {
+        throw new Error(`This gift has already been ${giftData.status.toLowerCase()}.`);
+      }
+      if (giftData.expiresAt.toMillis() < Date.now()) {
+        transaction.update(giftRef, { status: 'Expired' });
+        throw new Error('This gift has expired.');
+      }
+
+      const wordRef = doc(firestore, 'Words', giftData.wordText);
+      const wordSnap = await transaction.get(wordRef);
+      if (!wordSnap.exists() || (wordSnap.data() as MasterWordType)?.originalSubmitterUID) {
+        transaction.update(giftRef, { status: 'Expired', adminNotes: 'Word became unavailable.' });
+        throw new Error('Sorry, this word is no longer available to be claimed.');
+      }
+
+      transaction.update(wordRef, { originalSubmitterUID: userId });
+      transaction.update(giftRef, { status: 'Claimed', claimedAt: serverTimestamp() as Timestamp });
+
+      return { success: true, wordText: giftData.wordText };
+    });
+  } catch (error: any) {
+    console.error('Error claiming gifted word:', error);
+    return { success: false, error: error.message };
+  }
+}
+


### PR DESCRIPTION
## Summary
- add security rules for `WordGifts` documents
- create server action for claiming word gifts
- call the server action from `claim-word/[claimId]` page
- document claiming flow in README

## Testing
- `npm run lint` *(fails: `next` not found)*
- `npm run typecheck` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_687aa2eb28388327a9952ee90f1e2275