### PR TITLE
Remove unused icon imports

### DIFF
--- a/src/components/game/GameScreen.tsx
+++ b/src/components/game/GameScreen.tsx
@@ -8,7 +8,7 @@ import { WordEntryControls } from '@/components/game/WordEntryControls';
 import { GameTimer } from '@/components/game/GameTimer';
 import { SubmittedWordsList } from '@/components/game/SubmittedWordsList';
 import { Badge } from '@/components/ui/badge';
-import { PlayCircle, Check, Loader2, AlertTriangle, BellRing, Smartphone, Monitor } from 'lucide-react';
+import { PlayCircle, Check, Loader2, BellRing } from 'lucide-react';
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import Link from 'next/link';
 import { cn } from '@/lib/utils';


### PR DESCRIPTION
## Summary
- clean up GameScreen imports

## Testing
- `npm test` *(fails: Missing script)*
- `npx jest` *(fails: 403 Forbidden when fetching jest)*
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ab55e66f48327ae76961bd2f4d367