### PR TITLE
Remove unused FirebaseUser import

### DIFF
--- a/src/services/wordProcessingService.ts
+++ b/src/services/wordProcessingService.ts
@@ -3,7 +3,6 @@
 
 import { firestore } from '@/lib/firebase';
 import { collection, addDoc, serverTimestamp, doc, getDoc, updateDoc, increment, Timestamp, writeBatch, query, where, setDoc, getDocs } from 'firebase/firestore';
-import type { User as FirebaseUser } from 'firebase/auth'; // Assuming you pass the full FirebaseUser object or relevant parts
 import type { UserProfile, MasterWordType, RejectedWordType, WordSubmission, ClientMasterWordType } from '@/types';
 import { calculateWordScore } from '@/lib/scoring';
 import { checkWiktionary } from '@/ai/flows/check-wiktionary-flow';


### PR DESCRIPTION
## Summary
- clean up wordProcessingService by removing unused FirebaseUser type import

## Testing
- `npm test` *(fails: Missing script)*
- `npx jest` *(fails: 403 Forbidden - registry access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687ab554fc7c8327b91235a0670bf157