### PR TITLE
Add mobile bottom navigation

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import type { Metadata } from 'next';
 import './globals.css';
 import { SiteHeader } from '@/components/layout/SiteHeader';
 import { SiteFooter } from '@/components/layout/SiteFooter';
+import { BottomNav } from '@/components/layout/BottomNav';
 import { Toaster } from "@/components/ui/toaster";
 import { AuthProvider } from '@/contexts/AuthContext'; 
 import { SuggestionsBot } from '@/components/suggestions-bot/SuggestionsBot';
@@ -55,8 +56,9 @@ export default function RootLayout({
               {children}
             </main>
             <SiteFooter />
+            <BottomNav />
             <Toaster />
-            <SuggestionsBot /> 
+            <SuggestionsBot />
           </DeviceProvider>
         </AuthProvider>
       </body>

--- a/src/components/layout/BottomNav.tsx
+++ b/src/components/layout/BottomNav.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import { Home, Bell, UserCircle } from 'lucide-react';
+import { useIsMobile } from '@/hooks/use-mobile';
+import { cn } from '@/lib/utils';
+
+const NAV_ITEMS = [
+  { href: '/', label: 'Home', icon: Home },
+  { href: '/notifications', label: 'Alerts', icon: Bell },
+  { href: '/profile', label: 'Profile', icon: UserCircle },
+];
+
+export function BottomNav() {
+  const isMobile = useIsMobile();
+  const pathname = usePathname();
+
+  if (!isMobile) return null;
+
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 z-50 flex justify-around border-t bg-background py-2">
+      {NAV_ITEMS.map(({ href, label, icon: Icon }) => (
+        <Link key={href} href={href} className="flex flex-col items-center text-xs">
+          <Icon
+            className={cn(
+              'h-5 w-5',
+              pathname === href ? 'text-primary' : 'text-muted-foreground'
+            )}
+          />
+          <span>{label}</span>
+        </Link>
+      ))}
+    </nav>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add a BottomNav component that appears only on mobile
- integrate BottomNav into the site layout

## Testing
- `npm run typecheck` *(fails: Cannot find modules)*
- `npm run lint` *(fails: next not found)*
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687abb77ef708327a78c8ddcb61f06e1