### PR TITLE
Implement confirmation page for gifted words

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To get started, take a look at src/app/page.tsx.
 
 Administrators can gift unclaimed words to players. Gifts are stored in the
 `WordGifts` collection and include the recipient's user ID. When a player visits
-`/claim-word/[giftId]` the app calls a server action that performs a Firestore
-transaction to assign the word and mark the gift as claimed. Firestore security
-rules allow only the recipient to read the gift and update its `status` and
-`claimedAt` fields during this process.
+`/claim-word/[giftId]` they are shown a confirmation screen. Accepting the gift
+triggers a server action that assigns the word to the intended recipient and
+marks the gift as claimed. Declining simply expires the gift, leaving the word
+unowned. This process works even if the recipient is not logged in.


### PR DESCRIPTION
## Summary
- adjust README to describe updated flow for gifted words
- update claim-word actions to not require login and add decline handler
- update claim-word page to allow accepting or declining gift without sign-in

## Testing
- `npm run lint` *(fails: next not found)*
- `npm run typecheck` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ac03236c48327b5d25825c25e8eda